### PR TITLE
Update css dependency that fixes a security issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "pojo"
   ],
   "dependencies": {
-    "css": "2.2.1"
+    "css": "2.2.3"
   },
   "devDependencies": {
     "coveralls": "3.0.0",


### PR DESCRIPTION
I'm using `html-react-parser` and Snyk tells me that through `style-to-object`, it depends on a version of `reworkcss/css` that actually has a security risk.
Hopefully, [it has been fixed](https://github.com/reworkcss/css/commit/e91bb74051469d9c521b1b966460b44877e961fb). So here is a PR to propagate the fix in `style-to-object`.
Could you also do a release on `html-react-parser` once `style-to-object` will be released?

I'm not used to your commit message style. Is it something to do automatic changelogs? How should I amend mine?

By the way, I was wondering what was the reason behind choosing `reworkcss/css` for the CSS parser? It seems to be abandonned in favor of PostCSS. Even though, I guess PostCSS would be too big as a dependency, maybe there are lighter alternatives?

Anyway, thanks a lot for your work! It's great!