### PR TITLE
build(package): upgrade all dependencies and devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
 script:
   - npm run lint
   - npm run cover
+  - npm run build
 after_script:
   - npm run coveralls
 notifications:

--- a/package.json
+++ b/package.json
@@ -31,19 +31,19 @@
     "pojo"
   ],
   "dependencies": {
-    "css": "2.2.3"
+    "css": "2.2.4"
   },
   "devDependencies": {
-    "coveralls": "3.0.0",
-    "eslint": "4.11.0",
+    "coveralls": "3.0.2",
+    "eslint": "5.5.0",
     "istanbul": "0.4.5",
-    "mocha": "4.0.1",
-    "rollup": "0.51.5",
-    "rollup-plugin-commonjs": "8.2.6",
-    "rollup-plugin-node-resolve": "3.0.0",
-    "rollup-plugin-uglify": "2.0.1",
-    "standard-version": "4.2.0",
-    "uglify-es": "3.1.9"
+    "mocha": "5.2.0",
+    "rollup": "0.65.2",
+    "rollup-plugin-commonjs": "9.1.6",
+    "rollup-plugin-node-resolve": "3.4.0",
+    "rollup-plugin-uglify": "5.0.2",
+    "standard-version": "4.4.0",
+    "uglify-es": "3.3.9"
   },
   "license": "MIT"
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,14 +1,14 @@
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
-import uglify from 'rollup-plugin-uglify';
+import { uglify } from 'rollup-plugin-uglify';
 import { minify } from 'uglify-es';
 
 const config = {
   input: 'index.js',
   output: {
     format: 'umd',
+    name: 'StyleToObject',
   },
-  name: 'StyleToObject',
   plugins: [
     resolve(),
     commonjs(),


### PR DESCRIPTION
```
css                          2.2.3  →   2.2.4
coveralls                    3.0.1  →   3.0.2
eslint                      4.19.1  →   5.5.0
mocha                        5.1.1  →   5.2.0
rollup                      0.58.2  →  0.65.2
rollup-plugin-commonjs       9.1.3  →   9.1.6
rollup-plugin-node-resolve   3.3.0  →   3.4.0
rollup-plugin-uglify         3.0.0  →   5.0.2
standard-version             4.3.0  →   4.4.0
```

Related to [#70](https://github.com/remarkablemark/html-react-parser/issues/70)