### PR TITLE
perf: replace `css` with `inline-style-parser`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Output:
 Parse multiple declarations:
 
 ```js
-parse('border-color: #ACE; z-index: 1337;');
+parse(`
+  border-color: #ACE;
+  z-index: 1337;
+`);
 ```
 
 Output:
@@ -94,16 +97,25 @@ Output:
 { 'answer': '42' }
 ```
 
-Invalid declarations:
+Invalid declarations/arguments:
 
 ```js
-parse(1); // null
-parse('top:'); // null
 parse(`
   top: ;
   right: 1em;
 `); // { right: '1em' }
+
+parse();        // null
+parse(null);    // null
+parse(1);       // null
+parse(true);    // null
+parse('top:');  // null
+parse(':12px'); // null
+parse(':');     // null
+parse(';');     // null
+
 parse('top'); // throws Error
+parse('/*');  // throws Error
 ```
 
 ### Iterator
@@ -183,7 +195,7 @@ $ git push --follow-tags && npm publish
 
 ## Special Thanks
 
-- [css](https://github.com/reworkcss/css)
+- [inline-style-parser](https://github.com/remarkablemark/inline-style-parser)
 - [Contributors](https://github.com/remarkablemark/style-to-object/graphs/contributors)
 
 ## License

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var parse = require('css/lib/parse');
+var parse = require('inline-style-parser');
 
 /**
  * Parses inline style to object.
@@ -17,12 +17,9 @@ function StyleToObject(style, iterator) {
     return output;
   }
 
-  var hasIterator = typeof iterator === 'function';
-
-  // wrap declarations in a placeholder
-  var declarations = parse('a{' + style + '}').stylesheet.rules[0].declarations;
-
   var declaration;
+  var declarations = parse(style);
+  var hasIterator = typeof iterator === 'function';
   var property;
   var value;
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "pojo"
   ],
   "dependencies": {
-    "css": "2.2.4"
+    "inline-style-parser": "0.1.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",

--- a/test/data.js
+++ b/test/data.js
@@ -120,11 +120,12 @@ const cases = [
 ];
 
 const errors = [
-  // missing property
-  ':42',
+  // property missing ':'
+  'overflow',
+  '1',
 
-  // missing end of comment
-  '/*'
+  // end of comment missing
+  '/* unclosed comment'
 ];
 
 const invalids = [
@@ -142,6 +143,9 @@ const invalids = [
 
   // missing value
   'z-index:',
+  ':',
+  ':100px',
+  ';',
 
   // comment
   '/* color: #f00; */',

--- a/test/index.js
+++ b/test/index.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const css = require('css');
+const inlineStyleParser = require('inline-style-parser');
 const { cases, errors, invalids } = require('./data');
 const parse = require('..');
 
@@ -48,10 +48,7 @@ describe('iterator', () => {
     parse(style, (name, value, declaration) => {
       assert.equal(name, 'color');
       assert.equal(value, '#f00');
-      assert.deepEqual(
-        declaration,
-        css.parse(`p{${style}}`).stylesheet.rules[0].declarations[0]
-      );
+      assert.deepEqual(declaration, inlineStyleParser(style)[0]);
     });
   });
 
@@ -60,10 +57,7 @@ describe('iterator', () => {
     parse(style, (name, value, declaration) => {
       assert.equal(name, undefined);
       assert.equal(value, undefined);
-      assert.deepEqual(
-        declaration,
-        css.parse(`p{${style}}`).stylesheet.rules[0].declarations[0]
-      );
+      assert.deepEqual(declaration, inlineStyleParser(style)[0]);
     });
   });
 });


### PR DESCRIPTION
[`inline-style-parser`](https://github.com/remarkablemark/inline-style-parser) is smaller and more optimized than [`css`](https://github.com/reworkcss/css/blob/v2.2.4/lib/parse/index.js):

| package             | unminified    | minified |
| ------------------- | ------------- | -------- |
| css                 | 10.8 kB       | 6.75 kB  |
| inline-style-parser | 5.81 kB       | 1.79 kB  |

Sources:

- https://unpkg.com/css@2.2.4/lib/parse/
- https://unpkg.com/inline-style-parser@0.1.1/dist/