### PR TITLE
build(package): replace `rollup-plugin-terser` with `@rollup/plugin-terser`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@commitlint/config-conventional": "^17.0.0",
     "@rollup/plugin-commonjs": "^23.0.0",
     "@rollup/plugin-node-resolve": "^15.0.0",
+    "@rollup/plugin-terser": "^0.1.0",
     "dtslint": "^4.2.1",
     "eslint": "^8.16.0",
     "eslint-plugin-prettier": "^4.0.0",
@@ -61,7 +62,6 @@
     "pinst": "^3.0.0",
     "prettier": "^2.6.2",
     "rollup": "^2.75.3",
-    "rollup-plugin-terser": "^7.0.2",
     "typescript": "^4.7.2"
   },
   "files": [

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,6 +1,6 @@
 import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
-import { terser } from 'rollup-plugin-terser';
+import terser from '@rollup/plugin-terser';
 
 const config = {
   input: 'index.js',


### PR DESCRIPTION
## What is the motivation for this pull request?

build(package): replace `rollup-plugin-terser` with `@rollup/plugin-terser`

## What is the current behavior?

`rollup-plugin-terser` is no longer maintained

## What is the new behavior?

Replaced with `@rollup/plugin-terser`

## Checklist:

- [ ] Tests
- [ ] Documentation