### PR TITLE
fix: include types in export

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "index.d.ts",
   "module": "index.mjs",
   "exports": {
+    "types": "./index.d.ts",
     "import": "./index.mjs",
     "require": "./index.js"
   },


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Types cannot be used with TypeScript with ESM (`module: node16` in _tsconfig.json_)
For example https://github.com/remarkjs/react-markdown/pull/723
<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?

Types cannot be resolved.

## What is the new behavior?

Types can be resolved
<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)

<!--
Any other comments? Thank you for contributing!
-->

---

### additional notes

When a package is being loaded via native ESM with TypeScript in `node16` mode, it looks up the types from the `export` property in package.json
Defining a `types` property in `exports` allows for lookup of the typings

see: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing