### PR TITLE
build(rollup): generate sourcemap for UMD build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,7 @@
     "require": "./index.js"
   },
   "scripts": {
-    "build": "run-s build:*",
-    "build:min": "NODE_ENV=production rollup --config --file dist/style-to-object.min.js --sourcemap",
-    "build:unmin": "NODE_ENV=development rollup --config --file dist/style-to-object.js",
+    "build": "rollup --config --failAfterWarnings",
     "clean": "rm -rf dist",
     "lint": "eslint --ignore-path .gitignore .",
     "lint:fix": "npm run lint -- --fix",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,17 +2,20 @@ import commonjs from '@rollup/plugin-commonjs';
 import resolve from '@rollup/plugin-node-resolve';
 import terser from '@rollup/plugin-terser';
 
-const config = {
+/**
+ * Build rollup config for development or production.
+ */
+const getConfig = (minify = false) => ({
   input: 'index.js',
   output: {
+    file: `dist/style-to-object${minify ? '.min' : ''}.js`,
     format: 'umd',
-    name: 'StyleToObject'
+    name: 'StyleToObject',
+    sourcemap: true
   },
-  plugins: [commonjs(), resolve()]
-};
+  plugins: [commonjs(), resolve(), minify && terser()]
+});
 
-if (process.env.NODE_ENV === 'production') {
-  config.plugins.push(terser());
-}
+const configs = [getConfig(), getConfig(true)];
 
-export default config;
+export default configs;


### PR DESCRIPTION
Release-As: 0.4.3

## What is the motivation for this pull request?

build(rollup): generate sourcemap for UMD build

## What is the current behavior?

Unminified UMD dist build does not have sourcemap

## What is the new behavior?

Unminified UMD dist build has sourcemap

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation