### PR TITLE
fix(esm): fix ESM types by adding `esm/index.d.mts`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ jspm_packages
 # Build files
 cjs/
 dist/
+esm/index.d.mts
 
 # Vim swap files
 *.swp

--- a/package.json
+++ b/package.json
@@ -5,15 +5,14 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "./cjs/index.js",
   "module": "./esm/index.mjs",
-  "types": "./cjs/index.d.ts",
   "exports": {
-    "types": "./cjs/index.d.ts",
     "import": "./esm/index.mjs",
     "require": "./cjs/index.js"
   },
   "scripts": {
     "build": "run-s build:*",
     "build:cjs": "tsc",
+    "build:esm": "awk '!/sourceMappingURL/' cjs/index.d.ts > esm/index.d.mts",
     "build:umd": "rollup --config --failAfterWarnings",
     "clean": "rm -rf cjs coverage dist",
     "lint": "eslint --ignore-path .gitignore .",


### PR DESCRIPTION
## What is the motivation for this pull request?

Fixes #205

Fix ESM types by adding `esm/index.d.mts`

## What is the current behavior?

ESM types are wrong

## What is the new behavior?

Export `esm/index.d.mts`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation