### PR TITLE
chore(index): export StyleObject interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import parse from 'inline-style-parser';
 
 export { Declaration };
 
-interface StyleObject {
+export interface StyleObject {
   [name: string]: string;
 }
 


### PR DESCRIPTION
## What is the motivation for this pull request?

I also work with TypeScript, and I need to annotate a variable with the same type as the result of the main `StyleToObject` function.

## What is the current behavior?

Not exporting the `StyleObject` interface.

## What is the new behavior?

Exporting the `StyleObject` interface.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)