### PR TITLE
fix(package): fix esm types

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,3 +39,6 @@ jobs:
 
       - name: Build package
         run: npm run build
+
+      - name: Lint package
+        run: npm run lint:package

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
 npm run test:ci
+npm run test:esm
+npm run lint:package
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "author": "Mark <mark@remarkablemark.org>",
   "main": "./cjs/index.js",
   "module": "./esm/index.mjs",
-  "types": "./esm/index.d.mts",
+  "types": "./esm/index.d.ts",
   "exports": {
     "import": {
-      "types": "./esm/index.d.mts",
+      "types": "./esm/index.d.ts",
       "default": "./esm/index.mjs"
     },
     "require": {
@@ -24,6 +24,7 @@
     "clean": "rm -rf cjs coverage dist esm",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
+    "lint:package": "publint",
     "lint:tsc": "tsc --noEmit",
     "prepare": "husky",
     "prepublishOnly": "run-s lint lint:tsc test clean build",


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(package): fix esm types

Fixes #768

https://publint.dev/style-to-object@1.0.10

<img width="787" height="611" alt="Screenshot 2025-10-03 at 11 21 34 AM" src="https://github.com/user-attachments/assets/3854c4b7-f4d9-4f9a-abfe-fa25e41e53c6" />

## What is the current behavior?

Errors:
1. `pkg.exports.import.types` is `./esm/index.d.mts` but the file does not exist.
2. `pkg.types` is `./esm/index.d.mts` but the file does not exist.

Suggestions:
1. The package does not specify the "type" field. Node.js may attempt to detect the package type causing a small performance hit. Consider adding "type": "commonjs".

## What is the new behavior?

Fix package.json types and add publint:

```diff
-  "types": "./esm/index.d.mts",
+  "types": "./esm/index.d.ts",
   "exports": {
     "import": {
-      "types": "./esm/index.d.mts",
+      "types": "./esm/index.d.ts",
```

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation