### PR TITLE
fix: allow JS ESM smoke test to pass typed lint

### DIFF
--- a/__tests__/index.test.mjs
+++ b/__tests__/index.test.mjs
@@ -1,6 +1,6 @@
-import assert from 'assert';
+import assert from 'assert/strict';
 
 import parse from '../esm/index.mjs';
 
-assert.strictEqual(typeof parse, 'function');
+assert.equal(typeof parse, 'function');
 assert.deepEqual(parse('foo: bar'), { foo: 'bar' });

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -51,4 +51,10 @@ export default defineConfig(
       'simple-import-sort/imports': 'error',
     },
   },
+  {
+    files: ['**/*.{cjs,js,mjs}'],
+    rules: {
+      '@typescript-eslint/no-unsafe-call': 'off',
+    },
+  },
 );


### PR DESCRIPTION
## Summary
- Add a JavaScript-specific ESLint override for `@typescript-eslint/no-unsafe-call`.
- Keep the ESM smoke test as JavaScript while avoiding typed-lint false positives for built output imports.
- Use `assert/strict` in the ESM smoke test.

## Testing
- `npm run lint`
- `npm run lint:tsc`
- `npm test -- --runInBand`
- `npm run test:esm`
