### PR TITLE
fix(build): bundle inline-style-parser in UMD output and add page test CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,3 +42,10 @@ jobs:
 
       - name: Lint package
         run: npm run lint:package
+
+      - name: Test UMD page
+        uses: remarkablemark/page-test-action@v1
+        with:
+          url: http://localhost:8000/examples
+          start: python3 -m http.server
+          wait-on: http://localhost:8000

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,7 +7,9 @@ const external = ['inline-style-parser'];
 const baseConfig = {
   entry,
   sourcemap,
-  external,
+  deps: {
+    neverBundle: external,
+  },
 } satisfies UserConfig;
 
 const umdBase = {
@@ -15,7 +17,9 @@ const umdBase = {
   format: 'umd' as const,
   outDir: 'dist',
   globalName: 'StyleToObject',
-  noExternal: external,
+  deps: {
+    alwaysBundle: external,
+  },
 };
 
 export default defineConfig([


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Fix the UMD build and add automated testing for the UMD example page.

## What is the current behavior?

The UMD build treats `inline-style-parser` as an external dependency, causing a runtime error in the browser when loading the example page:

```text
Uncaught TypeError: (0 , e.default) is not a function
```

## What is the new behavior?

- The UMD build bundles `inline-style-parser` so the example page works standalone.
- The `tsdown` config uses the current `deps.neverBundle` / `deps.alwaysBundle` API instead of the deprecated `external` / `noExternal` options.
- A CI step has been added to test the UMD example page with `page-test-action`.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
